### PR TITLE
(maint) Downcase cd4pe team name in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @puppetlabs/CD4PE
+* @puppetlabs/cd4pe


### PR DESCRIPTION
The Open Source Stewards are claming that the CODEOWNERS file in this repo is malformed. The only differences between this one and our other repos are the space between the wildcard and the team name and that in our other repos, CD4PE is cd4pe. According the github, the space is fine but i closed it anyway and changed the team name to downcase cd4pe to see what happens.